### PR TITLE
fix(core): Bug in a fresh env

### DIFF
--- a/specs/004-cli-interface/spec.md
+++ b/specs/004-cli-interface/spec.md
@@ -122,6 +122,23 @@ A developer with an existing `.env` file wants to migrate to Envy without manual
 - **SC-005**: Every error scenario (missing manifest, bad key, vault unavailable) produces a human-readable message and exits with a non-zero code — no panics in any code path.
 - **SC-006**: The `run` command's exit code matches the child process exit code in 100% of tested scenarios, including non-zero exit codes and signal termination.
 
+## Known Bugs & Fixes
+
+### BUG-001: `envy run` crashes on a fresh project with no secrets (fixed)
+
+**Reported**: 2026-03-20
+**Status**: Fixed in `src/core/ops.rs`
+
+**Symptom**: Running `envy run -- <cmd>` immediately after `envy init`, before any `envy set` call, exited with `error: record not found` instead of executing the command.
+
+**Root cause**: `get_env_secrets()` called `vault.get_environment_by_name()` and propagated `DbError::NotFound` via `?`. On a fresh project no environment row exists yet (environments are auto-created lazily by `set_secret`, not by `init`), so the lookup always fails before any secrets have been stored.
+
+**Fix**: Handle `DbError::NotFound` explicitly in `get_env_secrets()` — return `Ok(HashMap::new())` instead of propagating the error. A missing environment is semantically equivalent to an environment with zero secrets for read-only operations.
+
+**Regression test added**: `core::ops::tests::get_env_secrets_missing_env_returns_empty`
+
+---
+
 ## Assumptions
 
 - The master key is retrievable from the OS credential store before any command that needs vault access. Commands that cannot retrieve the key fail fast with a clear message.

--- a/src/core/ops.rs
+++ b/src/core/ops.rs
@@ -205,7 +205,13 @@ pub fn get_env_secrets(
     env_name: &str,
 ) -> Result<HashMap<String, Zeroizing<String>>, CoreError> {
     let name = normalize_env(env_name);
-    let env = vault.get_environment_by_name(project_id, &name)?;
+    // A missing environment means no secrets have been set yet — return empty map
+    // rather than propagating NotFound. This makes `envy run` work on a fresh project.
+    let env = match vault.get_environment_by_name(project_id, &name) {
+        Ok(env) => env,
+        Err(DbError::NotFound) => return Ok(HashMap::new()),
+        Err(e) => return Err(CoreError::Db(e)),
+    };
     let records = vault.list_secrets(&env.id)?;
     let mut map = HashMap::new();
     for record in records {
@@ -374,6 +380,26 @@ mod tests {
         assert_eq!(secrets.get("A").map(|v| v.as_str()), Some("1"));
         assert_eq!(secrets.get("B").map(|v| v.as_str()), Some("2"));
         assert_eq!(secrets.get("C").map(|v| v.as_str()), Some("3"));
+    }
+
+    // Bug regression: get_env_secrets on a fresh project (environment never created)
+    // must return Ok(empty map), not Err — `envy run` crashed on first use.
+    #[test]
+    fn get_env_secrets_missing_env_returns_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (vault, pid) = open_test_vault(&tmp);
+
+        // Fresh project — no environments created, no secrets set whatsoever.
+        let result = get_env_secrets(&vault, &[0u8; 32], &pid, "development");
+        assert!(
+            result.is_ok(),
+            "missing environment must return Ok, not Err; got: {:?}",
+            result
+        );
+        assert!(
+            result.unwrap().is_empty(),
+            "result must be an empty map for a fresh project"
+        );
     }
 
     // T020


### PR DESCRIPTION
## Summary

- `envy run` crashed with `record not found` on a freshly initialised project (before any `envy set` call)
- `get_env_secrets()` was propagating `DbError::NotFound` when the environment row didn't exist yet, instead of returning an empty map
- Fix: handle `NotFound` explicitly and return `Ok(HashMap::new())` — a missing environment is semantically equivalent to zero secrets

## Test plan

- [x] Regression test added: `core::ops::tests::get_env_secrets_missing_env_returns_empty`
- [x] Full test suite passes: 34 unit tests, 38 DB tests, 0 failures
- [x] Bug documented in `specs/004-cli-interface/spec.md` as BUG-001
