### PR TITLE
fix: create ~/.envy dir before Init early return, not after

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -260,6 +260,14 @@ pub fn run() -> i32 {
         return 0;
     }
 
+    // --- Ensure ~/.envy/ exists for every command (including Init). ---
+    if let Some(vault_dir) = vault_path().parent() {
+        if let Err(e) = std::fs::create_dir_all(vault_dir) {
+            eprintln!("error: cannot create vault directory: {e}");
+            return 4;
+        }
+    }
+
     // --- Init is special: it manages its own vault lifecycle. ---
     if let Commands::Init = &cli.command {
         return match commands::cmd_init() {
@@ -298,13 +306,6 @@ pub fn run() -> i32 {
     };
 
     let vp = vault_path();
-    if let Some(vault_dir) = vp.parent() {
-        if let Err(e) = std::fs::create_dir_all(vault_dir) {
-            eprintln!("error: cannot create vault directory: {e}");
-            return 4;
-        }
-    }
-
     let vault = match crate::db::Vault::open(&vp, master_key.as_ref()) {
         Ok(v) => v,
         Err(e) => {


### PR DESCRIPTION
## Summary

- `envy init` was crashing on fresh CI machines because `Commands::Init` short-circuits early in `run()`, before reaching the shared `Vault::open` block where `create_dir_all` previously lived
- Moved `create_dir_all` to right after the `Completions` check — before the `Init` early return — so `~/.envy/` is guaranteed for every command including `init`
- Removed the now-duplicate block that was lower in `run()`

## Test plan

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Manual: delete `~/.envy`, run `envy init` on a fresh machine — directory is created, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)